### PR TITLE
Handle GIL Issue by measuring non-uniform time intervals

### DIFF
--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -49,7 +49,7 @@ class BaseEmissionsTracker(ABC):
         self._project_name: str = project_name
         self._measure_power_secs: int = measure_power_secs
         self._start_time: Optional[float] = None
-        self._last_measured_time: Optional[float] = None
+        self._last_measured_time: float = time.time()
         self._output_dir: str = output_dir
         self._total_energy: Energy = Energy.from_energy(kwh=0)
         self._scheduler = BackgroundScheduler()

--- a/codecarbon/emissions_tracker.py
+++ b/codecarbon/emissions_tracker.py
@@ -49,6 +49,7 @@ class BaseEmissionsTracker(ABC):
         self._project_name: str = project_name
         self._measure_power_secs: int = measure_power_secs
         self._start_time: Optional[float] = None
+        self._last_measured_time: Optional[float] = None
         self._output_dir: str = output_dir
         self._total_energy: Energy = Energy.from_energy(kwh=0)
         self._scheduler = BackgroundScheduler()
@@ -82,7 +83,7 @@ class BaseEmissionsTracker(ABC):
             logger.warning("Already started tracking")
             return
 
-        self._start_time = time.time()
+        self._last_measured_time = self._start_time = time.time()
         self._scheduler.start()
 
     def stop(self) -> Optional[float]:
@@ -164,8 +165,9 @@ class BaseEmissionsTracker(ABC):
         """
         self._total_energy += Energy.from_power_and_time(
             power=self._hardware.total_power,
-            time=Time.from_seconds(self._measure_power_secs),
+            time=Time.from_seconds(time.time()-self._last_measured_time),
         )
+        self._last_measured_time = time.time()
 
 
 class OfflineEmissionsTracker(BaseEmissionsTracker):

--- a/codecarbon/external/hardware.py
+++ b/codecarbon/external/hardware.py
@@ -61,7 +61,7 @@ class GPU(BaseHardware):
         return self._get_power_for_gpus(gpu_ids=gpu_ids)
 
     @classmethod
-    def from_utils(cls, gpu_ids) -> "GPU":
+    def from_utils(cls, gpu_ids: Optional[List] = None) -> "GPU":
         return cls(num_gpus=len(get_gpu_details()), gpu_ids=gpu_ids)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pynvml
 requests
 sphinx
 sphinx-rtd-theme
+mypy

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -23,5 +23,5 @@ class TestGPUMetadata(unittest.TestCase):
     ):
         gpu = GPU.from_utils()
         self.assertAlmostEqual(
-            0.032159, gpu.get_power_for_gpus(gpu_ids=[1]).kw, places=2
+            0.032159, gpu._get_power_for_gpus(gpu_ids=[1]).kw, places=2
         )


### PR DESCRIPTION
This PR handles 
- GIL issue by recording the last measured time when the Background Scheduler called the measure function in place of using a constant value.
- Initialize gpu_ids to a default null value in the initializer.